### PR TITLE
Use another PPA for Python 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV pip_packages "ansible"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        software-properties-common \
-    && add-apt-repository ppa:jonathonf/python-2.7 \
+    && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
        python2.7 \


### PR DESCRIPTION
As the PPA of jonathonf for python2.7 was restricted to private access (see https://launchpad.net/~jonathonf), we needed a new PPA here.